### PR TITLE
Add calibration data

### DIFF
--- a/registers.md
+++ b/registers.md
@@ -1,124 +1,124 @@
 # Register map
 
-| Reg ID | Description |
-|--------|-------------|
-|   0 |  ID |
-|   1 |  Serial number high bytes |
-|   2 |  Serial number low bytes |
-|   3 |  Firmware version |
-|   4 |  Temperature °c sign (0=+, 1=-) |
-|   5 |  Temperature °c |
-|   6 |  Temperature F sign (0=+, 1=-) |
-|   7 |  Temperature F |
-|   8 |  Voltage set value |
-|   9 |  Current set value |
-|  10 |  Voltage display value |
-|  11 |  Current display value |
-|  12 |  AH display value |
-|  13 |  Power display value |
-|  14 |  Voltage input |
-|  15 |  Keypad lock |
-|  16 |  Protection status (1=OVP, 2=OCP) |
-|  17 |  CV/CC (0=CV, 1=CC) |
-|  18 |  Output enable |
-|  19 |  Change preset |
-|  20 |  |
-|  21 |  |
-|  22 |  |
-|  23 |  |
-|  24 |  |
-|  25 |  |
-|  26 |  |
-|  27 |  |
-|  28 |  |
-|  29 |  |
-|  30 |  |
-|  31 |  |
-|  32 |  Battery mode active |
-|  33 |  Battery voltage |
-|  34 |  External temperature °c sign (0=+, 1=-) |
-|  35 |  External temperature °c |
-|  36 |  External temperature F sign (0=+, 1=-) |
-|  37 |  External temperature F |
-|  38 |  Ah high bytes |
-|  39 |  Ah low bytes |
-|  40 |  Wh high bytes |
-|  41 |  Wh low bytes |
-|  42 |  |
-|  43 |  |
-|  44 |  |
-|  45 |  |
-|  46 |  |
-|  47 |  |
-|  48 | Year |
-|  49 | Month |
-|  50 | Day |
-|  51 | Hour |
-|  52 | Minute |
-|  53 | Second |
-|  54 |  |
-|  55 |  |
-|  56 |  |
-|  57 |  |
-|  58 |  |
-|  59 |  |
-|  60 |  |
-|  61 |  |
-|  62 |  |
-|  63 |  |
-|  64 |  |
-|  65 |  |
-|  66 | Settings Take ok |
-|  67 | Settings Take out |
-|  68 | Settings Boot pow |
-|  69 | Settings Buzzer |
-|  70 | Settings Logo |
-|  71 | Settings Language |
-|  72 | Settings Backlight |
-|  73 |  |
-|  74 |  |
-|  75 |  |
-|  76 |  |
-|  77 |  |
-|  78 |  |
-|  79 |  |
-|  80 | M0 V |
-|  81 | M0 A |
-|  82 | M0 OVP |
-|  83 | M1 OCP |
-|  84 | M1 V |
-|  85 | M1 A |
-|  86 | M1 OVP |
-|  87 | M1 OCP |
-|  88 | M2 V |
-|  89 | M2 A |
-|  90 | M2 OVP |
-|  91 | M2 OCP |
-|  92 | M3 V |
-|  93 | M3 A |
-|  94 | M3 OVP |
-|  95 | M3 OCP |
-|  96 | M4 V |
-|  97 | M4 A |
-|  98 | M4 OVP |
-|  99 | M4 OCP |
-| 100 | M5 V |
-| 101 | M5 A |
-| 102 | M5 OVP |
-| 103 | M5 OCP |
-| 104 | M6 V |
-| 105 | M6 A |
-| 106 | M6 OVP |
-| 107 | M6 OCP |
-| 108 | M7 V |
-| 109 | M7 A |
-| 110 | M7 OVP |
-| 111 | M7 OCP |
-| 112 | M8 V |
-| 113 | M8 A |
-| 114 | M8 OVP |
-| 115 | M8 OCP |
-| 116 | M9 V |
-| 117 | M9 A |
-| 118 | M9 OVP |
-| 119 | M9 OCP |
+| Reg ID | Description | Used for| 
+|--------|-------------|---------|
+|   0 |  ID |  |
+|   1 |  Serial number high bytes |  |
+|   2 |  Serial number low bytes |  |
+|   3 |  Firmware version |  |
+|   4 |  Temperature °c sign (0=+, 1=-) |  |
+|   5 |  Temperature °c |  |
+|   6 |  Temperature F sign (0=+, 1=-) |  |
+|   7 |  Temperature F |  |
+|   8 |  Voltage set value |  |
+|   9 |  Current set value |  |
+|  10 |  Voltage display value |  |
+|  11 |  Current display value |  |
+|  12 |  AH display value |  |
+|  13 |  Power display value |  |
+|  14 |  Voltage input |  |
+|  15 |  Keypad lock |  |
+|  16 |  Protection status (1=OVP, 2=OCP) |  |
+|  17 |  CV/CC (0=CV, 1=CC) |  |
+|  18 |  Output enable |  |
+|  19 |  Change preset |  |
+|  20 |  |  |
+|  21 |  |  |
+|  22 |  |  |
+|  23 |  |  |
+|  24 |  |  |
+|  25 |  |  |
+|  26 |  |  |
+|  27 |  |  |
+|  28 |  |  |
+|  29 |  |  |
+|  30 |  |  |
+|  31 |  |  |
+|  32 |  Battery mode active |  |
+|  33 |  Battery voltage |  |
+|  34 |  External temperature °c sign (0=+, 1=-) |  |
+|  35 |  External temperature °c |  |
+|  36 |  External temperature F sign (0=+, 1=-) |  |
+|  37 |  External temperature F |  |
+|  38 |  Ah high bytes |  |
+|  39 |  Ah low bytes |  |
+|  40 |  Wh high bytes |  |
+|  41 |  Wh low bytes |  |
+|  42 |  |  |
+|  43 |  |  |
+|  44 |  |  |
+|  45 |  |  |
+|  46 |  |  |
+|  47 |  |  |
+|  48 | Year |  |
+|  49 | Month |  |
+|  50 | Day |  |
+|  51 | Hour |  |
+|  52 | Minute |  |
+|  53 | Second |  |
+|  54 |  |  |
+|  55 | Output Voltage Zero | Calibration Data |
+|  56 | Output Voltage Scale | Calibration Data |
+|  57 | Back Voltage Zero | Calibration Data |
+|  58 | Back Voltage Scale | Calibration Data |
+|  59 | Output Current Zero | Calibration Data |
+|  60 | Output Current Scale | Calibration Data |
+|  61 | Back Current Zero | Calibration Data |
+|  62 | Back Current Scale | Calibration Data |
+|  63 |  |  |
+|  64 |  |  |
+|  65 |  |  |
+|  66 | Settings Take ok |  |
+|  67 | Settings Take out |  |
+|  68 | Settings Boot pow |  |
+|  69 | Settings Buzzer |  |
+|  70 | Settings Logo |  |
+|  71 | Settings Language |  |
+|  72 | Settings Backlight |  |
+|  73 |  |  |
+|  74 |  |  |
+|  75 |  |  |
+|  76 |  |  |
+|  77 |  |  |
+|  78 |  |  |
+|  79 |  |  |
+|  80 | M0 V |  |
+|  81 | M0 A |  |
+|  82 | M0 OVP |  |
+|  83 | M1 OCP |  |
+|  84 | M1 V |  |
+|  85 | M1 A |  |
+|  86 | M1 OVP |  |
+|  87 | M1 OCP |  |
+|  88 | M2 V |  |
+|  89 | M2 A |  |
+|  90 | M2 OVP |  |
+|  91 | M2 OCP |  |
+|  92 | M3 V |  |
+|  93 | M3 A |  |
+|  94 | M3 OVP |  |
+|  95 | M3 OCP |  |
+|  96 | M4 V |  |
+|  97 | M4 A |  |
+|  98 | M4 OVP |  |
+|  99 | M4 OCP |  |
+| 100 | M5 V |  |
+| 101 | M5 A |  |
+| 102 | M5 OVP |  |
+| 103 | M5 OCP |  |
+| 104 | M6 V |  |
+| 105 | M6 A |  |
+| 106 | M6 OVP |  |
+| 107 | M6 OCP |  |
+| 108 | M7 V |  |
+| 109 | M7 A |  |
+| 110 | M7 OVP |  |
+| 111 | M7 OCP |  |
+| 112 | M8 V |  |
+| 113 | M8 A |  |
+| 114 | M8 OVP |  |
+| 115 | M8 OCP |  |
+| 116 | M9 V |  |
+| 117 | M9 A |  |
+| 118 | M9 OVP |  |
+| 119 | M9 OCP |  |


### PR DESCRIPTION
I found calibration data after sniffing
I used this code 
``` python
for x in range(247):
    print(f"{x} {device._read_register(x)}")
```

![calibration from GUI](https://user-images.githubusercontent.com/38077357/80394775-a01c8000-88b2-11ea-9fa3-e822f504827a.PNG)
![missing registers](https://user-images.githubusercontent.com/38077357/80394781-a27eda00-88b2-11ea-9bb1-d63bbc37e3bd.PNG)
