### PR TITLE
Document register 0x54

### DIFF
--- a/registers.md
+++ b/registers.md
@@ -56,7 +56,7 @@
 |  51 | Hour |  |
 |  52 | Minute |  |
 |  53 | Second |  |
-|  54 |  |  |
+|  54 | Commit calibration registers to NVRAM | Calibration Data |
 |  55 | Output Voltage Zero | Calibration Data |
 |  56 | Output Voltage Scale | Calibration Data |
 |  57 | Back Voltage Zero | Calibration Data |


### PR DESCRIPTION
Values written to the calibration registers (0x55 through 0x62) are not saved to NVRAM until the value 0x1501 is written to register 0x54. 

I worked this out by sniffing the serial port and running the RDTech PC software. It performs this commit operation when saving calibration.

Without the commit operation, the calibration values will revert when the PSU is power-cycled.

Here is my code that uses this module to write calibration values: https://github.com/simeonmiteff/cal-riden-psu

A short write-up about it: https://fdi.sk/posts/riden-cal/