### PR TITLE
setup.py: don't import rd6006

### DIFF
--- a/rd6006/__init__.py
+++ b/rd6006/__init__.py
@@ -1,4 +1,4 @@
 from .rd6006 import *
+from ._version import __version__
 
 name = "rd6006"
-__version__ = 0.2

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,15 @@
 
 import setuptools
 
-import rd6006
+with open("rd6006/_version.py", "r") as fh:
+    version = fh.readlines()[-1].split()[-1].strip("\"'")
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="rd6006",
-    version=rd6006.__version__,
+    version=version,
     author="Baldanos",
     author_email="balda@balda.ch",
     description="Python bindings for RD6006",


### PR DESCRIPTION
This makes it possible to install under poetry (and similar).

Before this change, you'd get an error like so:

    PackageInfoError

    Unable to determine package info for path: /home/cstrahan/src/cal-riden-psu/../rd6006

    Fallback egg_info generation failed.

    Command ['/tmp/tmp30wom7ih/.venv/bin/python', 'setup.py', 'egg_info'] errored with the following return code 1, and output:
    Traceback (most recent call last):
      File "/home/cstrahan/src/rd6006/setup.py", line 13, in <module>
        import rd6006
      File "/home/cstrahan/src/rd6006/rd6006/__init__.py", line 1, in <module>
        from .rd6006 import *
      File "/home/cstrahan/src/rd6006/rd6006/rd6006.py", line 1, in <module>
        import minimalmodbus
    ModuleNotFoundError: No module named 'minimalmodbus'

    at ~/.asdf/installs/poetry/1.1.14/lib/poetry/inspection/info.py:500 in _pep517_metadata
        496│                 try:
        497│                     venv.run_python("setup.py", "egg_info")
        498│                     return cls.from_metadata(path)
        499│                 except EnvCommandError as fbe:
      → 500│                     raise PackageInfoError(
        501│                         path, "Fallback egg_info generation failed.", fbe
        502│                     )
        503│                 finally:
        504│                     os.chdir(cwd.as_posix())

This commit resolves that.

See https://packaging.python.org/en/latest/guides/single-sourcing-package-version/